### PR TITLE
Increase user_id field size in db up to 64 bit

### DIFF
--- a/models.py
+++ b/models.py
@@ -9,7 +9,7 @@ db = Database()
 
 
 class Answer(db.Entity):
-    user_id = Required(int)
+    user_id = Required(int, size=64)
     username = Optional(str)
     text = Required(str, max_len=150)
     registered = Required(datetime, default=datetime.now)


### PR DESCRIPTION
Increase database integer field size from 32 to 64 bits due to large telegram user_id